### PR TITLE
Feat(library): Updated Endpoint For Library Indexing

### DIFF
--- a/crates/backend/src/routes/music.rs
+++ b/crates/backend/src/routes/music.rs
@@ -44,8 +44,8 @@ pub async fn songs_list(path: web::Path<String>) -> impl Responder {
     HttpResponse::Ok().body(message)
 }
 
-#[get("/library/index/{pathToLibrary}")]
-async fn process_library(path_to_library: web::Path<String>) -> impl Responder {
+#[get("/index/{pathToLibrary}")]
+pub async fn process_library(path_to_library: web::Path<String>) -> impl Responder {
     info!("Indexing library...");
     log_to_ws("Indexing library...".to_string()).await.unwrap();
 

--- a/crates/backend/src/routes/user.rs
+++ b/crates/backend/src/routes/user.rs
@@ -191,8 +191,6 @@ async fn get_user_info_by_id(path: web::Path<i32>) -> Result<impl Responder, Box
     Ok(HttpResponse::Ok().json(recieved_user))
 }
 
-
-
 pub fn configure(cfg: &mut web::ServiceConfig) {
   cfg.service(
       web::scope("/user")

--- a/packages/music-sdk/src/lib/library.ts
+++ b/packages/music-sdk/src/lib/library.ts
@@ -6,7 +6,7 @@ import axios from './axios';
  * @returns {Promise<string>} - A promise that resolves to a success message.
  */
 export async function indexLibrary(pathToLibrary: string): Promise<string> {
-  const response = await axios.post('/library/index', {
+  const response = await axios.post('/admin/library/index', {
 	path_to_library: pathToLibrary,
   });
   return response.data;


### PR DESCRIPTION
Changed the endpoint URL in the `indexLibrary` function to /admin/library/index to align with the updated API structure.