### PR TITLE
AppData for Storing Files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,6 +1228,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel_migrations"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a73ce704bad4231f001bff3314d91dce4aba0770cee8b233991859abc15c1f6"
+dependencies = [
+ "diesel",
+ "migrations_internals",
+ "migrations_macros",
+]
+
+[[package]]
 name = "diesel_table_macro_syntax"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,6 +2819,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "migrations_internals"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd01039851e82f8799046eabbb354056283fb265c8ec0996af940f4e85a380ff"
+dependencies = [
+ "serde",
+ "toml 0.8.19",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb161cc72176cb37aa47f1fc520d3ef02263d67d661f44f05d05a079e1237fd"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2886,6 +2918,8 @@ dependencies = [
  "chrono",
  "diesel",
  "diesel-async",
+ "diesel_migrations",
+ "dirs",
  "dotenvy",
  "fancy-regex",
  "futures",

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -20,6 +20,8 @@ audiotags = "0.5"
 chrono = { version = "0.4.38", features = ["serde"] }
 diesel = { version = "2.1.0", features = ["chrono", "numeric", "r2d2"]}
 diesel-async = { version = "0.5.0", features = ["sqlite"] }
+diesel_migrations = { version = "2.2.0", features = ["sqlite"] }
+dirs = "5.0.1"
 dotenvy = "0.15.0"
 fancy-regex = "0.13.0"
 futures = "*"

--- a/crates/backend/src/routes/music.rs
+++ b/crates/backend/src/routes/music.rs
@@ -57,8 +57,12 @@ pub async fn process_library(path_to_library: web::Path<String>) -> impl Respond
         .build()
         .unwrap();
 
-    let mut current_library: Vec<Artist> =
-        serde_json::from_str(get_config().await.unwrap_or("".to_string()).as_str()).unwrap();
+    let config_data = get_config().await.unwrap_or("".to_string());
+    let mut current_library: Vec<Artist> = if config_data.is_empty() {
+        Vec::new()
+    } else {
+        serde_json::from_str(&config_data).unwrap_or_else(|_| Vec::new())
+    };
 
     if current_library.is_empty() {
         let mut library_guard = library.lock().unwrap();

--- a/crates/backend/src/utils/globals.rs
+++ b/crates/backend/src/utils/globals.rs
@@ -1,5 +1,4 @@
 use std::sync::Mutex;
-
 use actix_ws::Session;
 use lazy_static::lazy_static;
 

--- a/crates/backend/src/utils/websocket.rs
+++ b/crates/backend/src/utils/websocket.rs
@@ -22,8 +22,8 @@ pub async fn log_to_ws(message: impl Into<String>) -> Result<(), Box<dyn std::er
     if let Some(session) = session_lock.as_mut() {
         session.text(&message).await?;
     } else {
-        eprintln!("No active session found");
-        return Err("No active session found".into());
+        info!("No active session found, message not sent");
+        return Ok(());
     }
     Ok(())
 }

--- a/packages/music-sdk/src/lib/library.ts
+++ b/packages/music-sdk/src/lib/library.ts
@@ -6,8 +6,9 @@ import axios from './axios';
  * @returns {Promise<string>} - A promise that resolves to a success message.
  */
 export async function indexLibrary(pathToLibrary: string): Promise<string> {
-  const response = await axios.post('/admin/library/index', {
-	path_to_library: pathToLibrary,
+  const encodedPath = encodeURIComponent(pathToLibrary);
+  const response = await axios.get(`/library/index/${encodedPath}`, {
+    baseURL: ''
   });
   return response.data;
 }


### PR DESCRIPTION
Increased separation between Git Repository and Stored Data by using the Operating System's AppData Folder. Contained within, holds 
`Album Covers` - Previously `missing_cover_art`, contains all of the album covers not found in the library through indexing
`Artist Icons` - Previously `missing_icon_art`, contains all of the artist's icon art not found in the library through indexing
`Config` -  Previously `apps/web/Config` & `/Config`. This contains the main config file used for just about everything related to music
`Database` - Previously stored in the root location is the stored playlists, user and more.
`Meilisearch` - Used for the searching client.

These are located in the different application data found in the different operating systems and will be automatically found depending on the operating system the server resides:

Windows: `C:\Users\<Username>\AppData\Local`
Linux:` /home/<Username>/.local/share`
macOS: `/Users/<Username>/Library/Application Support`

With regards to the Database (`music.db`) and Meilisearch, they will be automatically created with the migrations already ran and downloaded along with checks on every run of the server. Meilisearch will also be ran on a separate thread without the use of the `start.ts` script.