### PR TITLE
Fix New Albums not Containing Music Videos

### DIFF
--- a/apps/web/app/(app)/album/AlbumComponent.tsx
+++ b/apps/web/app/(app)/album/AlbumComponent.tsx
@@ -297,11 +297,6 @@ export default function AlbumComponent() {
                       </Button>
                     </Link>
                   ))}
-                  {album.release_group_album?.aliases.map((alias) => (
-                    <p key={alias.name} className="mb-2">
-                      {alias.name}
-                    </p>
-                  ))}
                 </div>
               </div>
             </div>

--- a/crates/backend/src/structures/structures.rs
+++ b/crates/backend/src/structures/structures.rs
@@ -22,7 +22,8 @@ pub struct Artist {
     pub icon_url: String,
     pub followers: u64,
     pub albums: Vec<Album>,
-    pub description: String
+    pub description: String,
+    pub tadb_music_videos: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/crates/backend/src/utils/library.rs
+++ b/crates/backend/src/utils/library.rs
@@ -72,7 +72,7 @@ files.par_iter().for_each(|entry| {
       let artist = if let Some(artist_position) = artist_position {
           &mut library[artist_position]
       } else {
-          let new_artist = Artist { id: hash_artist(&artist_name), name: artist_name.clone(), albums: Vec::new(), icon_url: String::new(), followers: 0, description: String::new() };
+          let new_artist = Artist { id: hash_artist(&artist_name), name: artist_name.clone(), albums: Vec::new(), icon_url: String::new(), followers: 0, description: String::new(), tadb_music_videos: None };
           library.push(new_artist);
           library.last_mut().unwrap()
       };


### PR DESCRIPTION
If artists are already defined, they will not process TADB metadata used for music videos, this is because it would require a new API request. To fix this, `tadb_music_videos` has been added to the artist struct solely in the backend to store all of the metadata to then be refreshed when a new album comes with a defined artist.