### PR TITLE
Redo Migrations from the Server

### DIFF
--- a/crates/backend/migrations/2024-07-21-200400_music/up.sql
+++ b/crates/backend/migrations/2024-07-21-200400_music/up.sql
@@ -77,7 +77,8 @@ CREATE TABLE IF NOT EXISTS "server_info" (
     "version" TEXT NOT NULL,
     "product_name" TEXT NOT NULL,
     "startup_wizard_completed" BOOLEAN NOT NULL DEFAULT FALSE,
-    "login_disclaimer" TEXT
+    "login_disclaimer" TEXT,
+    CONSTRAINT unique_server_info UNIQUE ("server_name", "local_address")
 );
 
 CREATE UNIQUE INDEX "user_username_key" ON "user"("username");

--- a/crates/backend/src/routes/database.rs
+++ b/crates/backend/src/routes/database.rs
@@ -1,0 +1,25 @@
+use std::error::Error;
+use actix_web::{post, web, HttpResponse, Responder};
+use actix_web_httpauth::middleware::HttpAuthentication;
+
+use crate::utils::database::database::redo_migrations;
+
+use super::authentication::admin_guard;
+
+#[post("/redo_migrations")]
+async fn redo_migrations_handler() -> Result<impl Responder, Box<dyn Error>> {
+    match redo_migrations() {
+        Ok(_) => Ok(HttpResponse::Ok().body("Migrations redone successfully")),
+        Err(e) => Ok(HttpResponse::InternalServerError().body(format!("Error redoing migrations: {}", e))),
+    }
+}
+
+pub fn configure(cfg: &mut web::ServiceConfig) {
+    let admin = HttpAuthentication::with_fn(admin_guard);
+
+    cfg.service(
+      web::scope("/database")
+        .wrap(admin)
+        .service(redo_migrations_handler)
+    );
+}

--- a/crates/backend/src/routes/mod.rs
+++ b/crates/backend/src/routes/mod.rs
@@ -11,3 +11,4 @@ pub mod server;
 pub mod social;
 pub mod song;
 pub mod user;
+pub mod database;

--- a/crates/backend/src/routes/server.rs
+++ b/crates/backend/src/routes/server.rs
@@ -31,11 +31,14 @@ async fn set_server_info(info: web::Json<ServerInfo>) -> Result<impl Responder, 
         version: info.version.clone(),
         product_name: info.product_name.clone(),
         startup_wizard_completed: info.startup_wizard_completed,
-        login_disclaimer: Some(info.login_disclaimer.clone().unwrap_or_default()),
+        login_disclaimer: info.login_disclaimer.clone(),
     };
 
-    diesel::replace_into(server_info)
+    diesel::insert_into(server_info)
         .values(&new_info)
+        .on_conflict((server_name, local_address))
+        .do_update()
+        .set(&new_info)
         .execute(&mut connection)?;
 
     Ok(HttpResponse::Ok().body("Server info set successfully"))

--- a/crates/backend/src/utils/database/database.rs
+++ b/crates/backend/src/utils/database/database.rs
@@ -70,6 +70,16 @@ pub fn run_migrations() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     Ok(())
 }
 
+pub fn redo_migrations() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    let pool = establish_connection();
+    let mut conn = pool.get().expect("Failed to get a connection from the pool");
+
+    conn.revert_last_migration(MIGRATIONS)?;
+    conn.run_pending_migrations(MIGRATIONS)?;
+
+    Ok(())
+}
+
 pub fn migrations_ran() -> bool {
     let pool = establish_connection();
     let mut conn = pool.get().expect("Failed to get a connection from the pool");

--- a/crates/backend/src/utils/database/database.rs
+++ b/crates/backend/src/utils/database/database.rs
@@ -45,6 +45,7 @@ pub fn establish_connection() -> DbPool {
     let database_url = get_database_path().to_str().unwrap().to_string();
     let manager = ConnectionManager::<SqliteConnection>::new(database_url);
     let pool = r2d2::Pool::builder()
+        .max_size(16)
         .connection_customizer(Box::new(ConnectionOptions {
             enable_wal: true,
             enable_foreign_keys: true,
@@ -60,19 +61,10 @@ pub fn establish_connection() -> DbPool {
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./migrations");
 
 pub fn run_migrations() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let pool = establish_connection();
-    let mut conn = pool.get().expect("Failed to get a connection from the pool");
+    let database_url = get_database_path().to_str().unwrap().to_string();
+    let mut conn = SqliteConnection::establish(&database_url)
+        .expect("Failed to establish a database connection.");
 
-    conn.run_pending_migrations(MIGRATIONS)?;
-
-    Ok(())
-}
-
-pub fn redo_migrations() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
-    let pool = establish_connection();
-    let mut conn = pool.get().expect("Failed to get a connection from the pool");
-
-    conn.revert_last_migration(MIGRATIONS)?;
     conn.run_pending_migrations(MIGRATIONS)?;
 
     Ok(())

--- a/crates/backend/src/utils/database/models.rs
+++ b/crates/backend/src/utils/database/models.rs
@@ -121,7 +121,7 @@ pub struct PlaylistToSong {
     pub date_added: NaiveDateTime,
 }
 
-#[derive(Queryable, Selectable, Serialize, Deserialize, Insertable)]
+#[derive(Queryable, Selectable, Serialize, Deserialize, Insertable, AsChangeset)]
 #[diesel(table_name = server_info)]
 pub struct ServerInfo {
     pub local_address: String,


### PR DESCRIPTION
When redoing migrations with Diesel (`diesel migration redo`), it will need the `DATABASE_URL` to be set or specified with `--database-url`. Due to the fact that ParsonLabs Music's configuration files can be anywhere, the --redo flag has been added, in development, run `cargo run -- redo` which will prompt a yes or no dialog to redo the migrations in the database, automatically finding the database path.